### PR TITLE
Support Erlang 17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
  CC ?= /opt/gnu/gcc/4.7.3/bin/g++
 
 #
- REBAR_BIN  = ./rebar
+ REBAR_BIN ?= ./rebar
 
  REBAR_ENV  =
  REBAR_ENV += PATH=$(ERLANG_HOME)/bin:$(PATH)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ eroonga: erlang client for [groonga](http://groonga.org/).
 $ make build
 ```
 
+Note: included rebar binary is for Erlang 16. If you want to use eroonga on Erlang 17, specify rebar path:
+
+``` sh
+$ REBAR_BIN=rebar make build
+```
+
 ## Example
 
 ```erlang

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- erlang -*-
 
- {require_otp_vsn, "R16"}.
+ {require_otp_vsn, "(R16|17).*"}.
  {require_min_otp_vsn, "R16B"}.
 
  {erl_opts, [
@@ -33,5 +33,5 @@
  {deps, [
          {baseline, ".*", {git, "git://github.com/tomaon/baseline.git", "master"}},
          {jsonx, ".*", {git, "git://github.com/iskra/jsonx.git", "master"}},
-         {poolboy, ".*", {git,"git://github.com/devinus/poolboy",{tag,"1.0.1"}}}
+         {poolboy, ".*", {git,"git://github.com/devinus/poolboy",{tag,"1.5.1"}}}
         ]}.


### PR DESCRIPTION
I tried to support Erlang 17. It's probably compatible with Erlang 16.
- Update require_otp_vsn in rebar.config.
- Update Poolboy to 1.5.1.
  - See https://github.com/devinus/poolboy/blob/1.5.1/src/poolboy.erl#L15-L19
- Accept to specify REBAR_BIN.
- Document how to specify REBAR_BIN's path.
