### PR TITLE
Fix rebar path to follow ./rebar is removed in the repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
  CC ?= /opt/gnu/gcc/4.7.3/bin/g++
 
 #
- REBAR_BIN ?= ./rebar
+ REBAR_BIN ?= rebar
 
  REBAR_ENV  =
  REBAR_ENV += PATH=$(ERLANG_HOME)/bin:$(PATH)


### PR DESCRIPTION
I think we should use `rebar` in system environment as default.
Because `./rebar` is removed in the repository.
